### PR TITLE
添加手动触发的选项，修改 Readme 描述

### DIFF
--- a/.github/workflows/index.yml
+++ b/.github/workflows/index.yml
@@ -1,5 +1,6 @@
 name: RSS Everyday
 on: 
+  workflow_dispatch:
   schedule:
     - cron: '0 */4 * * *'
 #env:

--- a/README.md
+++ b/README.md
@@ -11,14 +11,16 @@ RSS_EVERYDAY 是一个 RSS 订阅工具，它会每四小时采集一次新的�
 创建一个 Channel，添加之前创建的 bot 为管理员，添加方式：  
 点击频道右上角的`管理频道 - 管理员 - 添加管理员`，搜索你创建的 bot 名称，将其添加为管理员即可，发送消息的权限必须赋予，其他权限可选。  
 
-[点此登陆](https://web.telegram.org) 网页版 telegram。点击你刚才创建的频道，链接格式类似 `https://web.telegram.org/#/im?p=cxxx_ppp` ，`-110xxx` 为你的频道 ID，记下它，之后要用到。  
+[点此登陆](https://web.telegram.org) 网页版 telegram。点击你刚才创建的频道，链接格式类似 `https://web.telegram.org/#/im?p=cxxx_ppp` ，在这种情况下 `-100xxx` 为你的 Channel ID。  
 
 ### TG Group 创建
 创建一个群组，添加之前创建的 bot 为管理员，添加方式类似 Channel。  
 
-[点此登陆](https://web.telegram.org) 网页版 telegram。点击你刚才创建的频道，链接格式类似 `https://web.telegram.org/#/im?p=gxxx` ，`-xxx` 为你的 Group ID。  
+[点此登陆](https://web.telegram.org) 网页版 telegram。点击你刚才创建的群组，链接格式类似`https://web.telegram.org/#/im?p=sxxx_ppp` ，在这种情况下 `-100xxx` 为你的 Group ID。
+或者也有可能类似 `https://web.telegram.org/#/im?p=gxxx` ，在这种情况下 `-xxx` 为你的 Group ID。  
+
 ### github 配置
-克隆本仓库，在仓库的 `Settings-Secrets` 新增两个字段 `BOTTOKEN` 和 `CHANNELID`，他们的值分别是你的 bot token 和 Channel ID/Group ID。
+克隆本仓库，在仓库的 `Settings-Secrets` 新增两个字段 `BOTTOKEN` 和 `CHANNELID` ，他们的值分别是你的 bot token 和 Channel ID/Group ID。
 
 
 ### RSS 源添加
@@ -28,4 +30,4 @@ RSS_EVERYDAY 是一个 RSS 订阅工具，它会每四小时采集一次新的�
 ## 注意事项
 代码中是使用发布时间进行筛选的，如果你所订阅的 RSS 链接无法解析出该字段，建议不要将该链接添加至 rss.json 文件。
 
-此项目是基于 Github Action 的定时任务实现的，并且只会在达到设定时间的情况下才会触发 Action。此 Action 不会被推送代码等操作主动触发。
+此项目是基于 Github Action 的定时任务实现的，并且只会在达到设定时间的情况下才会触发 Action ，也可以手动触发。

--- a/README_en.md
+++ b/README_en.md
@@ -15,7 +15,8 @@ Create a Channel, add the previously created bot as an administrator:
 ### Create TG Group
 Create a group. The way add bot to group is same with channel. 
 
-[Login here](https://web.telegram.org) The web version of telegram. Click on the channel you just created. The link format is similar to `https://web.telegram.org/#/im?p=gxxx`, where `-xxx` is your group ID.  
+[Login here](https://web.telegram.org) The web version of telegram. Click on the channel you just created. The link format is similar to `https://web.telegram.org/#/im?p=gxxx`, where `-xxx` is your group ID. Or maybe it is similar to `https://web.telegram.org/#/im?p=sxxx_ppp`, in which case `-100xxx` is your group ID.
+
 ### Github Configuration
 Clone this repository and add two new fields `BOTTOKEN` and `CHANNELID` to the `Settings-Secrets` of the repository. Their values are your bot token and channel/group ID respectively.
 
@@ -26,4 +27,4 @@ If the website itself provides an RSS link, you can directly add it in the forma
 ## Precautions
 The code uses the publication time to filter. If the RSS link you subscribe to cannot parse the field, it is recommended not to add the link to the rss.json file.
 
-This project is based on the timing task of Github Action, and the Action will only be triggered when the set time is reached. This Action will not be actively triggered by operations such as pushing code.
+This project is based on the timing task of Github Action, and the Action will only be triggered when the set time is reached. You can also manually trigger the action to test its availability.


### PR DESCRIPTION
在部署过程中发现Readme中有笔误，Channel ID 的前缀应该是 `-100` 而非 `-110`，不过也有可能是个例。另外，现在新建的Group默认是 Supergroup，所以也加上了这种情况。